### PR TITLE
##20/Phase 1: フロントエンド基盤構築1.3 ベース実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,15 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { DeviceList } from './components/DeviceList/DeviceList';
-import { DeviceForm } from './components/DeviceForm/DeviceForm';
-import './App.css';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import { RouterProvider } from 'react-router-dom';
+import { theme } from './theme';
+import { router } from './routes';
 
 function App() {
   return (
-    <Router>
-      <div className="App">
-        <Routes>
-          <Route path="/" element={<Navigate to="/devices" replace />} />
-          <Route path="/devices" element={<DeviceList />} />
-          <Route path="/devices/create" element={<DeviceForm />} />
-          <Route path="/devices/edit/:id" element={<DeviceForm />} />
-        </Routes>
-      </div>
-    </Router>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <RouterProvider router={router} />
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,61 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { Box, Typography, Button } from '@mui/material';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+    error: null,
+  };
+
+  public static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('エラー詳細:', error, errorInfo);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          minHeight="60vh"
+          gap={2}
+        >
+          <Typography variant="h4" color="error">
+            エラーが発生しました
+          </Typography>
+          <Typography variant="body1" color="textSecondary">
+            申し訳ありません。予期せぬエラーが発生しました。
+          </Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={this.handleReload}
+          >
+            ページを再読み込み
+          </Button>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+} 

--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,14 @@
+import { CircularProgress, Box } from '@mui/material';
+
+export const LoadingSpinner = () => {
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      minHeight="200px"
+    >
+      <CircularProgress />
+    </Box>
+  );
+}; 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,27 @@
+import { AppBar, Toolbar, Typography, IconButton } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+
+interface HeaderProps {
+  onMenuClick: () => void;
+}
+
+export const Header = ({ onMenuClick }: HeaderProps) => {
+  return (
+    <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+      <Toolbar>
+        <IconButton
+          color="inherit"
+          aria-label="メニューを開く"
+          edge="start"
+          onClick={onMenuClick}
+          sx={{ mr: 2 }}
+        >
+          <MenuIcon />
+        </IconButton>
+        <Typography variant="h6" noWrap component="div">
+          {import.meta.env.VITE_APP_NAME}
+        </Typography>
+      </Toolbar>
+    </AppBar>
+  );
+}; 

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,0 +1,40 @@
+import { Box, Container } from '@mui/material';
+import { useState } from 'react';
+import { Header } from './Header';
+import { Sidebar } from './Sidebar';
+import { Outlet } from 'react-router-dom';
+
+const drawerWidth = 240;
+
+export const Layout = () => {
+  const [open, setOpen] = useState(true);
+
+  const handleDrawerToggle = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <Header onMenuClick={handleDrawerToggle} />
+      <Sidebar
+        open={open}
+        onClose={handleDrawerToggle}
+        drawerWidth={drawerWidth}
+      />
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          p: 3,
+          width: { sm: `calc(100% - ${drawerWidth}px)` },
+          ml: { sm: `${drawerWidth}px` },
+          mt: '64px',
+        }}
+      >
+        <Container maxWidth="lg">
+          <Outlet />
+        </Container>
+      </Box>
+    </Box>
+  );
+}; 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,47 @@
+import { Drawer, List, ListItem, ListItemIcon, ListItemText, Toolbar } from '@mui/material';
+import DevicesIcon from '@mui/icons-material/Devices';
+import { useNavigate } from 'react-router-dom';
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+  drawerWidth: number;
+}
+
+export const Sidebar = ({ open, onClose, drawerWidth }: SidebarProps) => {
+  const navigate = useNavigate();
+
+  const menuItems = [
+    { text: 'デバイス一覧', icon: <DevicesIcon />, path: '/devices' },
+  ];
+
+  return (
+    <Drawer
+      variant="permanent"
+      sx={{
+        width: drawerWidth,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': {
+          width: drawerWidth,
+          boxSizing: 'border-box',
+        },
+      }}
+      open={open}
+      onClose={onClose}
+    >
+      <Toolbar />
+      <List>
+        {menuItems.map((item) => (
+          <ListItem
+            button
+            key={item.text}
+            onClick={() => navigate(item.path)}
+          >
+            <ListItemIcon>{item.icon}</ListItemIcon>
+            <ListItemText primary={item.text} />
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+}; 

--- a/frontend/src/pages/devices/DeviceDetail.tsx
+++ b/frontend/src/pages/devices/DeviceDetail.tsx
@@ -1,0 +1,12 @@
+import { Box, Typography } from '@mui/material';
+
+export const DeviceDetail = () => {
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        デバイス詳細
+      </Typography>
+      {/* TODO: デバイス詳細の実装 */}
+    </Box>
+  );
+}; 

--- a/frontend/src/pages/devices/DeviceForm.tsx
+++ b/frontend/src/pages/devices/DeviceForm.tsx
@@ -1,0 +1,12 @@
+import { Box, Typography } from '@mui/material';
+
+export const DeviceForm = () => {
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        デバイス登録
+      </Typography>
+      {/* TODO: デバイスフォームの実装 */}
+    </Box>
+  );
+}; 

--- a/frontend/src/pages/devices/DeviceList.tsx
+++ b/frontend/src/pages/devices/DeviceList.tsx
@@ -1,0 +1,12 @@
+import { Box, Typography } from '@mui/material';
+
+export const DeviceList = () => {
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        デバイス一覧
+      </Typography>
+      {/* TODO: デバイス一覧の実装 */}
+    </Box>
+  );
+}; 

--- a/frontend/src/pages/error/NotFound.tsx
+++ b/frontend/src/pages/error/NotFound.tsx
@@ -1,0 +1,31 @@
+import { Box, Typography, Button } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+export const NotFound = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      minHeight="60vh"
+      gap={2}
+    >
+      <Typography variant="h1" color="primary">
+        404
+      </Typography>
+      <Typography variant="h5" color="textSecondary">
+        ページが見つかりません
+      </Typography>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => navigate('/')}
+      >
+        ホームに戻る
+      </Button>
+    </Box>
+  );
+}; 

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,0 +1,36 @@
+import { createBrowserRouter } from 'react-router-dom';
+import { Layout } from '../components/layout/Layout';
+import { NotFound } from '../pages/error/NotFound';
+import { DeviceList } from '../pages/devices/DeviceList';
+import { DeviceDetail } from '../pages/devices/DeviceDetail';
+import { DeviceForm } from '../pages/devices/DeviceForm';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Layout />,
+    errorElement: <NotFound />,
+    children: [
+      {
+        path: '/',
+        element: <DeviceList />,
+      },
+      {
+        path: '/devices',
+        element: <DeviceList />,
+      },
+      {
+        path: '/devices/:id',
+        element: <DeviceDetail />,
+      },
+      {
+        path: '/devices/new',
+        element: <DeviceForm />,
+      },
+      {
+        path: '/devices/:id/edit',
+        element: <DeviceForm />,
+      },
+    ],
+  },
+]); 

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,0 +1,42 @@
+import { createTheme } from '@mui/material/styles';
+
+export const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+      light: '#42a5f5',
+      dark: '#1565c0',
+    },
+    secondary: {
+      main: '#9c27b0',
+      light: '#ba68c8',
+      dark: '#7b1fa2',
+    },
+    error: {
+      main: '#d32f2f',
+    },
+    background: {
+      default: '#f5f5f5',
+    },
+  },
+  typography: {
+    fontFamily: [
+      '-apple-system',
+      'BlinkMacSystemFont',
+      '"Segoe UI"',
+      'Roboto',
+      '"Helvetica Neue"',
+      'Arial',
+      'sans-serif',
+    ].join(','),
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+  },
+}); 


### PR DESCRIPTION
## issue
- closes  #20 

# 20/Phase 1: フロントエンド基盤構築1.3 ベース実装

## 📝 実装内容

### 1. プロジェクト構造の作成
以下のディレクトリ構造を実装：
```
src/
├── components/
│   ├── layout/
│   │   ├── Header.tsx（ヘッダーコンポーネント）
│   │   ├── Sidebar.tsx（サイドバーコンポーネント）
│   │   └── Layout.tsx（メインレイアウト）
│   └── common/
│       ├── LoadingSpinner.tsx（ローディング表示）
│       └── ErrorBoundary.tsx（エラーハンドリング）
├── pages/
│   ├── devices/
│   │   ├── DeviceList.tsx（一覧ページ）
│   │   ├── DeviceDetail.tsx（詳細ページ）
│   │   └── DeviceForm.tsx（作成/編集フォーム）
│   └── error/
│       └── NotFound.tsx（404ページ）
├── routes/
│   └── index.tsx（ルーティング設定）
└── theme/
    └── index.ts（Material-UIテーマ）
```

### 2. Material-UIのテーマ設定
- カラーパレットの定義
- タイポグラフィの設定
- ボタンスタイルのカスタマイズ

### 3. レイアウトコンポーネントの実装
- ヘッダー：アプリ名とメニューボタンを表示
- サイドバー：ナビゲーションメニューを実装
- メインレイアウト：コンテンツ領域の設定

### 4. 共通コンポーネントの実装
- `LoadingSpinner`：ローディング状態の表示
- `ErrorBoundary`：エラーハンドリングとフォールバックUI

### 5. ルーティング設定
以下のルートを実装：
- `/`: デバイス一覧
- `/devices`: デバイス一覧
- `/devices/:id`: デバイス詳細
- `/devices/new`: デバイス作成
- `/devices/:id/edit`: デバイス編集

### 6. エラーページの実装
- 404ページの実装
- ホームへの戻るボタンを設置

## ✅ 動作確認済み項目
1. プロジェクト構造の作成
2. Material-UIテーマの適用
3. レイアウトコンポーネントの基本表示
4. ルーティングの動作
5. エラーページの表示

## 📝 補足
- デバイス関連の各ページ（一覧・詳細・フォーム）は基本構造のみ実装
- 具体的なデータ取得・表示ロジックは次のフェーズで実装予定
