### PR TITLE
##21/Phase 2: 画面実装2.1 共通コンポーネント

### DIFF
--- a/frontend/src/components/common/Button/index.tsx
+++ b/frontend/src/components/common/Button/index.tsx
@@ -1,0 +1,57 @@
+import { Button as MuiButton, CircularProgress } from '@mui/material';
+import { ButtonProps } from './types';
+
+export const Button = ({
+  children,
+  variant = 'primary',
+  loading = false,
+  disabled,
+  fullWidth = false,
+  ...props
+}: ButtonProps) => {
+  // variantに基づいてMUIのvariantとcolorを設定
+  const getButtonProps = () => {
+    switch (variant) {
+      case 'primary':
+        return { variant: 'contained' as const, color: 'primary' as const };
+      case 'secondary':
+        return { variant: 'contained' as const, color: 'secondary' as const };
+      case 'danger':
+        return { variant: 'contained' as const, color: 'error' as const };
+      case 'text':
+        return { variant: 'text' as const, color: 'primary' as const };
+      default:
+        return { variant: 'contained' as const, color: 'primary' as const };
+    }
+  };
+
+  const { variant: muiVariant, color } = getButtonProps();
+
+  return (
+    <MuiButton
+      {...props}
+      variant={muiVariant}
+      color={color}
+      disabled={disabled || loading}
+      fullWidth={fullWidth}
+      sx={{
+        position: 'relative',
+        minWidth: '120px',
+        ...props.sx,
+      }}
+    >
+      {loading && (
+        <CircularProgress
+          size={24}
+          sx={{
+            position: 'absolute',
+            color: 'inherit',
+          }}
+        />
+      )}
+      <span style={{ visibility: loading ? 'hidden' : 'visible' }}>
+        {children}
+      </span>
+    </MuiButton>
+  );
+}; 

--- a/frontend/src/components/common/Button/types.ts
+++ b/frontend/src/components/common/Button/types.ts
@@ -1,0 +1,7 @@
+import { ButtonProps as MuiButtonProps } from '@mui/material';
+
+export interface ButtonProps extends Omit<MuiButtonProps, 'variant'> {
+  variant?: 'primary' | 'secondary' | 'danger' | 'text';
+  loading?: boolean;
+  fullWidth?: boolean;
+} 

--- a/frontend/src/components/common/Card/index.tsx
+++ b/frontend/src/components/common/Card/index.tsx
@@ -1,0 +1,47 @@
+import {
+  Card as MuiCard,
+  CardHeader,
+  CardContent,
+  Alert,
+} from '@mui/material';
+import { LoadingSpinner } from '../LoadingSpinner';
+import { CardProps } from './types';
+
+export const Card = ({
+  children,
+  title,
+  subtitle,
+  headerAction,
+  loading = false,
+  error,
+  ...props
+}: CardProps) => {
+  return (
+    <MuiCard
+      {...props}
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        ...props.sx,
+      }}
+    >
+      {title && (
+        <CardHeader
+          title={title}
+          subheader={subtitle}
+          action={headerAction}
+        />
+      )}
+      <CardContent sx={{ flexGrow: 1, position: 'relative' }}>
+        {loading ? (
+          <LoadingSpinner />
+        ) : error ? (
+          <Alert severity="error">{error}</Alert>
+        ) : (
+          children
+        )}
+      </CardContent>
+    </MuiCard>
+  );
+}; 

--- a/frontend/src/components/common/Card/types.ts
+++ b/frontend/src/components/common/Card/types.ts
@@ -1,0 +1,10 @@
+import { CardProps as MuiCardProps } from '@mui/material';
+import { ReactNode } from 'react';
+
+export interface CardProps extends MuiCardProps {
+  title?: string;
+  subtitle?: string;
+  headerAction?: ReactNode;
+  loading?: boolean;
+  error?: string;
+} 

--- a/frontend/src/components/common/Dialog/index.tsx
+++ b/frontend/src/components/common/Dialog/index.tsx
@@ -1,0 +1,57 @@
+import {
+  Dialog as MuiDialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from '@mui/material';
+import { Button } from '../Button';
+import { DialogProps } from './types';
+
+export const Dialog = ({
+  title,
+  children,
+  confirmText = '確認',
+  cancelText = 'キャンセル',
+  onConfirm,
+  onCancel,
+  loading = false,
+  confirmDisabled = false,
+  confirmVariant = 'primary',
+  ...props
+}: DialogProps) => {
+  return (
+    <MuiDialog
+      {...props}
+      onClose={(event, reason) => {
+        if (loading) return;
+        if (props.onClose) {
+          props.onClose(event, reason);
+        }
+      }}
+    >
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>{children}</DialogContent>
+      <DialogActions>
+        {onCancel && (
+          <Button
+            variant="text"
+            onClick={onCancel}
+            disabled={loading}
+          >
+            {cancelText}
+          </Button>
+        )}
+        {onConfirm && (
+          <Button
+            variant={confirmVariant}
+            onClick={onConfirm}
+            loading={loading}
+            disabled={confirmDisabled}
+          >
+            {confirmText}
+          </Button>
+        )}
+      </DialogActions>
+    </MuiDialog>
+  );
+}; 

--- a/frontend/src/components/common/Dialog/types.ts
+++ b/frontend/src/components/common/Dialog/types.ts
@@ -1,0 +1,14 @@
+import { DialogProps as MuiDialogProps } from '@mui/material';
+import { ReactNode } from 'react';
+
+export interface DialogProps extends Omit<MuiDialogProps, 'title'> {
+  title: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  loading?: boolean;
+  confirmDisabled?: boolean;
+  confirmVariant?: 'primary' | 'secondary' | 'danger';
+  children: ReactNode;
+} 

--- a/frontend/src/components/common/Table/index.tsx
+++ b/frontend/src/components/common/Table/index.tsx
@@ -1,0 +1,67 @@
+import {
+  Table as MuiTable,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Alert,
+} from '@mui/material';
+import { LoadingSpinner } from '../LoadingSpinner';
+import { TableProps, Column } from './types';
+
+export const Table = <T extends object>({
+  columns,
+  rows,
+  loading = false,
+  error,
+  onRowClick,
+  getRowId = (row: T) => (row as any).id,
+  ...props
+}: TableProps<T>) => {
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+
+  return (
+    <TableContainer component={Paper}>
+      <MuiTable {...props}>
+        <TableHead>
+          <TableRow>
+            {columns.map((column) => (
+              <TableCell
+                key={String(column.field)}
+                style={{ width: column.width }}
+              >
+                {column.headerName}
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow
+              key={getRowId(row)}
+              hover={!!onRowClick}
+              onClick={() => onRowClick?.(row)}
+              sx={{ cursor: onRowClick ? 'pointer' : 'default' }}
+            >
+              {columns.map((column) => (
+                <TableCell key={String(column.field)}>
+                  {column.renderCell
+                    ? column.renderCell(row)
+                    : row[column.field]?.toString()}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </MuiTable>
+    </TableContainer>
+  );
+}; 

--- a/frontend/src/components/common/Table/types.ts
+++ b/frontend/src/components/common/Table/types.ts
@@ -1,0 +1,18 @@
+import { TableProps as MuiTableProps } from '@mui/material';
+import { ReactNode } from 'react';
+
+export interface Column<T> {
+  field: keyof T;
+  headerName: string;
+  width?: number;
+  renderCell?: (row: T) => ReactNode;
+}
+
+export interface TableProps<T> extends Omit<MuiTableProps, 'rows'> {
+  columns: Column<T>[];
+  rows: T[];
+  loading?: boolean;
+  error?: string;
+  onRowClick?: (row: T) => void;
+  getRowId?: (row: T) => string;
+} 

--- a/frontend/src/components/common/TextField/index.tsx
+++ b/frontend/src/components/common/TextField/index.tsx
@@ -1,0 +1,30 @@
+import { TextField as MuiTextField, CircularProgress } from '@mui/material';
+import { TextFieldProps } from './types';
+
+export const TextField = ({
+  loading = false,
+  touched = false,
+  errorMessage,
+  helperText,
+  disabled,
+  ...props
+}: TextFieldProps) => {
+  const hasError = touched && Boolean(errorMessage);
+
+  return (
+    <MuiTextField
+      {...props}
+      error={hasError}
+      helperText={hasError ? errorMessage : helperText}
+      disabled={disabled || loading}
+      InputProps={{
+        ...props.InputProps,
+        endAdornment: loading ? (
+          <CircularProgress size={20} />
+        ) : (
+          props.InputProps?.endAdornment
+        ),
+      }}
+    />
+  );
+}; 

--- a/frontend/src/components/common/TextField/types.ts
+++ b/frontend/src/components/common/TextField/types.ts
@@ -1,0 +1,7 @@
+import { StandardTextFieldProps } from '@mui/material';
+
+export interface TextFieldProps extends StandardTextFieldProps {
+  loading?: boolean;
+  touched?: boolean;
+  errorMessage?: string;
+} 

--- a/frontend/src/pages/devices/DeviceList.tsx
+++ b/frontend/src/pages/devices/DeviceList.tsx
@@ -1,12 +1,78 @@
-import { Box, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { Table } from '../../components/common/Table';
+import { Device } from '../../types/device';
+import apiClient from '../../api/client';
+import { Column } from '../../components/common/Table/types';
 
 export const DeviceList = () => {
+  const navigate = useNavigate();
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDevices = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.get('/api/v1/devices/');
+      setDevices(response.data);
+    } catch (err) {
+      setError('デバイスの取得に失敗しました');
+      console.error('Error fetching devices:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDevices();
+  }, []);
+
+  const columns: Column<Device>[] = [
+    { field: 'name' as keyof Device, headerName: '機器名', width: 200 },
+    { field: 'manufacturer' as keyof Device, headerName: 'メーカー', width: 200 },
+    {
+      field: 'actions' as keyof Device,
+      headerName: '操作',
+      width: 120,
+      renderCell: (row: Device) => (
+        <Button
+          variant="contained"
+          size="small"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/devices/${row.id}/edit`);
+          }}
+        >
+          編集
+        </Button>
+      ),
+    },
+  ];
+
   return (
     <Box>
-      <Typography variant="h4" gutterBottom>
-        デバイス一覧
-      </Typography>
-      {/* TODO: デバイス一覧の実装 */}
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+        <Typography variant="h4" gutterBottom>
+          機器一覧
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => navigate('/devices/new')}
+        >
+          新規登録
+        </Button>
+      </Box>
+
+      <Table
+        columns={columns}
+        rows={devices}
+        loading={loading}
+        error={error || undefined}
+      />
     </Box>
   );
 }; 


### PR DESCRIPTION
## issue
- closes  #21 

# 21/Phase 2: 画面実装2.1 共通コンポーネント

## 🎯 実装の目的
最低限のUIで機器管理システムの基本機能（一覧表示、登録、編集）を実装。

## 📝 実装した機能

### 1. 共通コンポーネント
#### Button (`src/components/common/Button/`)
- カスタマイズ可能なボタンコンポーネント
- ローディング状態の表示
- バリアント: primary, secondary, danger, text
- 幅設定オプション

#### Card (`src/components/common/Card/`)
- タイトル、サブタイトル表示機能
- ヘッダーアクション対応
- ローディング状態とエラー表示
- コンテンツの柔軟なレイアウト

#### Dialog (`src/components/common/Dialog/`)
- 確認・キャンセルボタン
- ローディング状態制御
- カスタマイズ可能なボタンバリアント
- モーダルウィンドウの制御

#### TextField (`src/components/common/TextField/`)
- Material-UIの拡張
- エラーメッセージ表示機能
- ローディングインジケータ
- タッチ状態の管理

#### Table (`src/components/common/Table/`)
- カスタマイズ可能なカラム定義
- ローディング状態表示
- エラー表示機能
- 行クリックイベント対応

### 2. 機器管理機能
#### 機器一覧画面 (`src/pages/devices/DeviceList.tsx`)
- 機器データの取得と表示
- 新規登録ボタン
- 各行の編集ボタン
- エラーハンドリング

#### 機器フォーム画面 (`src/pages/devices/DeviceForm.tsx`)
- 新規登録/編集の共通フォーム
- バリデーション
- 保存後の一覧画面への自動遷移
- キャンセル機能

## 🔍 確認した内容

### 1. 型の整合性
- TextFieldコンポーネントの型エラーを修正
  - `error`プロパティを`errorMessage`に変更
  - boolean型とstring型の互換性問題を解決

### 2. コンポーネントの動作
- 各共通コンポーネントの基本機能
- ローディング状態の表示
- エラーハンドリング
- イベントハンドリング

### 3. 画面遷移
- 一覧画面 ⇔ 登録/編集画面の遷移
- フォーム送信後の自動遷移

## 🛠️ 技術スタック
- React 18.2.0
- TypeScript
- Material-UI
- React Router DOM

## ⚠️ 注意点
1. TextFieldコンポーネントの使用時は以下のプロパティを適切に設定：
```typescript
<TextField
  touched={boolean}
  errorMessage={string}
  loading={boolean}
/>
```

2. 一覧画面のテーブルカラム定義時は適切な型指定が必要：
```typescript
const columns: Column<Device>[] = [
  { field: 'name' as keyof Device, ... }
];
```

## 📋 今後の課題
1. ユニットテストの追加
2. エラーメッセージの国際化対応
3. フォームのバリデーション強化
4. レスポンシブデザインの改善

## 🔄 レビュー項目
- [ ] 型定義の正確性
- [ ] エラーハンドリングの適切性
- [ ] コンポーネントの再利用性
- [ ] 画面遷移の正常動作
- [ ] コードの一貫性
