### PR TITLE
##23/Phase 2: 画面実装2.3 機器登録画面

### DIFF
--- a/backend/lambda/devices/handlers/device_handlers.py
+++ b/backend/lambda/devices/handlers/device_handlers.py
@@ -85,7 +85,7 @@ def create_device(device: DeviceCreate, db: Session = Depends(get_db)):
 def list_devices(db: Session = Depends(get_db)):
     """全デバイスを取得"""
     try:
-        devices = db.query(Device).all()
+        devices = db.query(Device).order_by(Device.created_at.desc()).all()
         return UnicodeJSONResponse(
             content=[{
                 "name": device.name,

--- a/frontend/src/pages/devices/DeviceForm.tsx
+++ b/frontend/src/pages/devices/DeviceForm.tsx
@@ -1,12 +1,148 @@
-import { Box, Typography } from '@mui/material';
+import { useState } from 'react';
+import { Box, Typography, Stack, Alert, Snackbar } from '@mui/material';
+import { useNavigate, useParams } from 'react-router-dom';
+import { TextField } from '../../components/common/TextField';
+import { Button } from '../../components/common/Button';
+import { DeviceCreate } from '../../types/device';
+import apiClient from '../../api/client';
 
 export const DeviceForm = () => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [formData, setFormData] = useState<DeviceCreate>({
+    name: '',
+    manufacturer: '',
+  });
+  const [touched, setTouched] = useState({
+    name: false,
+    manufacturer: false,
+  });
+
+  const handleChange = (field: keyof DeviceCreate) => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: event.target.value,
+    }));
+    setTouched((prev) => ({
+      ...prev,
+      [field]: true,
+    }));
+  };
+
+  const validateForm = () => {
+    const errors: Partial<Record<keyof DeviceCreate, string>> = {};
+    
+    if (!formData.name) {
+      errors.name = '機器名は必須です';
+    }
+    if (!formData.manufacturer) {
+      errors.manufacturer = 'メーカー名は必須です';
+    }
+    
+    return errors;
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    
+    // 全てのフィールドをタッチ済みにする
+    setTouched({
+      name: true,
+      manufacturer: true,
+    });
+
+    const errors = validateForm();
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await apiClient.post('/api/v1/devices/', formData);
+      setSuccessMessage('機器を登録しました');
+      setTimeout(() => {
+        navigate('/devices');
+      }, 2000);
+    } catch (err) {
+      console.error('Error creating device:', err);
+      setError('機器の登録に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const errors = validateForm();
+
   return (
-    <Box>
-      <Typography variant="h4" gutterBottom>
-        デバイス登録
-      </Typography>
-      {/* TODO: デバイスフォームの実装 */}
+    <Box component="form" onSubmit={handleSubmit}>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+        <Typography variant="h4" gutterBottom>
+          機器登録
+        </Typography>
+      </Box>
+
+      <Stack spacing={3} maxWidth="600px">
+        <TextField
+          label="機器名"
+          value={formData.name}
+          onChange={handleChange('name')}
+          touched={touched.name}
+          errorMessage={touched.name ? errors.name : undefined}
+          required
+          fullWidth
+        />
+
+        <TextField
+          label="メーカー名"
+          value={formData.manufacturer}
+          onChange={handleChange('manufacturer')}
+          touched={touched.manufacturer}
+          errorMessage={touched.manufacturer ? errors.manufacturer : undefined}
+          required
+          fullWidth
+        />
+
+        <Box display="flex" gap={2}>
+          <Button
+            variant="text"
+            onClick={() => navigate('/devices')}
+            disabled={loading}
+          >
+            キャンセル
+          </Button>
+          <Button
+            type="submit"
+            loading={loading}
+            disabled={loading || Object.keys(errors).length > 0}
+          >
+            登録
+          </Button>
+        </Box>
+      </Stack>
+
+      <Snackbar
+        open={!!successMessage}
+        autoHideDuration={3000}
+        onClose={() => setSuccessMessage(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert onClose={() => setSuccessMessage(null)} severity="success">
+          {successMessage}
+        </Alert>
+      </Snackbar>
+
+      {error && (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          {error}
+        </Alert>
+      )}
     </Box>
   );
 }; 


### PR DESCRIPTION
## issue
- closes  #23

# プルリクエスト: 機器登録画面の実装 (#23)

## 📝 実装内容

### 1. 機器登録フォームの実装
- `DeviceForm.tsx` コンポーネントの作成
- Material-UIを使用した入力フォーム
  - 機器名入力フィールド
  - メーカー名入力フィールド
  - 登録/キャンセルボタン

### 2. バリデーション機能
- フロントエンド側
  ```typescript
  const validateForm = () => {
    const errors: Partial<Record<keyof DeviceCreate, string>> = {};
    if (!formData.name) errors.name = '機器名は必須です';
    if (!formData.manufacturer) errors.manufacturer = 'メーカー名は必須です';
    return errors;
  };
  ```
- バックエンド側
  - 必須項目チェック
  - 文字数制限（VARCHAR(255)）

### 3. エラーハンドリング
- API通信エラー
- バリデーションエラー
- データベースエラー
- ユーザーフレンドリーなエラーメッセージ表示

### 4. UI/UX改善
- ローディング状態の表示
- 成功メッセージの表示
- 登録後の自動遷移
- 新規登録アイテムの表示順序の最適化（created_at DESC）

## ✅ 動作確認項目と結果

### 1. フォーム基本機能
- [x] 入力フィールドの表示
- [x] 必須項目の表示
- [x] ボタンの配置と動作

### 2. バリデーション
- [x] 空データ送信時のエラー表示
- [x] 文字数制限（255文字）のチェック
- [x] 特殊文字・日本語の入力対応

### 3. API連携
- [x] 登録APIの呼び出し
- [x] レスポンスの処理
- [x] エラーハンドリング

### 4. エラーケース
- [x] ネットワークエラー
- [x] バリデーションエラー
- [x] データベースエラー
- [x] 文字数制限エラー

### 5. 画面遷移
- [x] 登録成功時の一覧画面への遷移
- [x] キャンセルボタンでの一覧画面への遷移

### 6. データ表示順序
- [x] 新規登録アイテムが一覧の先頭に表示

## 🔍 テスト結果

### APIテスト
```bash
# バリデーションエラー
curl -X POST http://localhost:8000/api/v1/devices/ \
  -H "Content-Type: application/json" \
  -d '{"name":"","manufacturer":""}'
→ 正しくエラーレスポンス返却

# 文字数制限テスト
$longName = "a" * 256
→ データベースエラーを正しく検出
```

### UI動作確認
- フォーム入力
- エラーメッセージ表示
- 登録成功時の遷移
- 一覧での表示順序

## 📚 関連ファイル
1. `frontend/src/pages/devices/DeviceForm.tsx`
2. `backend/lambda/devices/handlers/device_handlers.py`
3. `frontend/src/types/device.ts`

## 🔄 変更履歴
```git
feat(#23): 機器登録画面の実装
- フォームの基本機能実装
- バリデーション機能の追加
- エラーハンドリングの実装
- 日本語エラーメッセージの対応

fix(#23): デバイス一覧の表示順序を修正
- 新規登録したデバイスが一番上に表示されるように変更
- created_atの降順でソートするように実装
```

## 📋 残課題（将来の改善点）
1. フォームのリセット機能
2. 入力値の文字数表示
3. より詳細なバリデーション
4. フォームの入力補助機能