### PR TITLE
##24/Phase 2: 画面実装2.4 機器編集画面

### DIFF
--- a/backend/lambda/devices/handlers/device_handlers.py
+++ b/backend/lambda/devices/handlers/device_handlers.py
@@ -1,7 +1,8 @@
 import json
+import re
 from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional
 from ..database import get_db
 from ..models import Device
 from ..schemas import DeviceCreate, Device as DeviceSchema
@@ -41,6 +42,31 @@ def validate_uuid(device_id: str) -> bool:
     except ValueError:
         return False
 
+def validate_device_input(db: Session, device: DeviceCreate, device_id: Optional[str] = None):
+    """デバイス入力の検証"""
+    # 重複チェック
+    query = db.query(Device).filter(
+        Device.name == device.name,
+        Device.manufacturer == device.manufacturer
+    )
+    if device_id:  # 更新時は自身を除外
+        query = query.filter(Device.id != device_id)
+    
+    existing_device = query.first()
+    if existing_device:
+        raise ValidationError(
+            f"この機器（機器名：{device.name}、メーカー：{device.manufacturer}）は既に登録されています",
+            {"field": "duplicate"}
+        )
+
+    # 文字種チェック - より広い文字種を許可
+    pattern = r'^[a-zA-Z0-9ぁ-んァ-ンー一-龥\s\-_.,&!@#()（）［］・、。]+$'
+    if not re.match(pattern, device.name) or not re.match(pattern, device.manufacturer):
+        raise ValidationError(
+            "使用できない文字が含まれています。使用可能な文字：日本語、英数字、記号（. , & ! @ # ( ) （ ） ［ ］ ・ 、 。 - _）",
+            {"field": "format"}
+        )
+
 @router.post("/devices/", response_model=DeviceSchema, status_code=201)
 def create_device(device: DeviceCreate, db: Session = Depends(get_db)):
     """新しいデバイスを作成"""
@@ -50,6 +76,9 @@ def create_device(device: DeviceCreate, db: Session = Depends(get_db)):
             raise ValidationError("デバイス名は必須です", {"field": "name"})
         if not device.manufacturer:
             raise ValidationError("メーカー名は必須です", {"field": "manufacturer"})
+
+        # 重複と文字種のバリデーション
+        validate_device_input(db, device)
 
         db_device = Device(
             id=str(uuid.uuid4()),
@@ -178,6 +207,9 @@ def update_device(device_id: str, device: DeviceCreate, db: Session = Depends(ge
             raise ValidationError("デバイス名は必須です", {"field": "name"})
         if not device.manufacturer:
             raise ValidationError("メーカー名は必須です", {"field": "manufacturer"})
+
+        # 重複と文字種のバリデーション
+        validate_device_input(db, device, device_id)
 
         db_device = db.query(Device).filter(Device.id == device_id).first()
         if db_device is None:

--- a/frontend/src/pages/devices/DeviceForm.tsx
+++ b/frontend/src/pages/devices/DeviceForm.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Typography, Stack, Alert, Snackbar } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
 import { TextField } from '../../components/common/TextField';
 import { Button } from '../../components/common/Button';
-import { DeviceCreate } from '../../types/device';
+import { Device, DeviceCreate } from '../../types/device';
 import apiClient from '../../api/client';
+import { Dialog } from '../../components/common/Dialog';
 
 export const DeviceForm = () => {
   const navigate = useNavigate();
@@ -12,6 +13,7 @@ export const DeviceForm = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [formData, setFormData] = useState<DeviceCreate>({
     name: '',
     manufacturer: '',
@@ -20,6 +22,36 @@ export const DeviceForm = () => {
     name: false,
     manufacturer: false,
   });
+
+  useEffect(() => {
+    const fetchDevice = async () => {
+      if (!id) return;
+      
+      setLoading(true);
+      setError(null);
+      
+      try {
+        const response = await apiClient.get(`/api/v1/devices/${id}`);
+        const device: Device = response.data;
+        setFormData({
+          name: device.name,
+          manufacturer: device.manufacturer,
+        });
+      } catch (err: any) {
+        console.error('Error fetching device:', err);
+        if (err.response?.data?.error?.message) {
+          setError(err.response.data.error.message);
+        } else {
+          setError('デバイスの取得に失敗しました');
+        }
+        navigate('/devices');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDevice();
+  }, [id, navigate]);
 
   const handleChange = (field: keyof DeviceCreate) => (
     event: React.ChangeEvent<HTMLInputElement>
@@ -43,6 +75,14 @@ export const DeviceForm = () => {
     if (!formData.manufacturer) {
       errors.manufacturer = 'メーカー名は必須です';
     }
+
+    const pattern = /^[a-zA-Z0-9ぁ-んァ-ンー一-龥\s\-_.,&!@#()（）［］・、。]+$/;
+    if (formData.name && !pattern.test(formData.name)) {
+      errors.name = '使用できない文字が含まれています。使用可能な文字：日本語、英数字、記号（. , & ! @ # ( ) （ ） ［ ］ ・ 、 。 - _）';
+    }
+    if (formData.manufacturer && !pattern.test(formData.manufacturer)) {
+      errors.manufacturer = '使用できない文字が含まれています。使用可能な文字：日本語、英数字、記号（. , & ! @ # ( ) （ ） ［ ］ ・ 、 。 - _）';
+    }
     
     return errors;
   };
@@ -50,7 +90,6 @@ export const DeviceForm = () => {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     
-    // 全てのフィールドをタッチ済みにする
     setTouched({
       name: true,
       manufacturer: true,
@@ -65,16 +104,41 @@ export const DeviceForm = () => {
     setError(null);
 
     try {
-      await apiClient.post('/api/v1/devices/', formData);
-      setSuccessMessage('機器を登録しました');
+      if (id) {
+        await apiClient.put(`/api/v1/devices/${id}`, formData);
+        setSuccessMessage('機器を更新しました');
+      } else {
+        await apiClient.post('/api/v1/devices/', formData);
+        setSuccessMessage('機器を登録しました');
+      }
       setTimeout(() => {
         navigate('/devices');
       }, 2000);
-    } catch (err) {
-      console.error('Error creating device:', err);
-      setError('機器の登録に失敗しました');
+    } catch (err: any) {
+      console.error('Error saving device:', err);
+      if (err.response?.data?.error?.message) {
+        setError(err.response.data.error.message);
+        
+        if (err.response.data.error.details?.field === 'duplicate') {
+          setTouched({
+            name: true,
+            manufacturer: true,
+          });
+        }
+      } else {
+        setError(id ? '機器の更新に失敗しました' : '機器の登録に失敗しました');
+      }
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    const isFormDirty = touched.name || touched.manufacturer;
+    if (isFormDirty) {
+      setShowCancelDialog(true);
+    } else {
+      navigate('/devices');
     }
   };
 
@@ -84,7 +148,7 @@ export const DeviceForm = () => {
     <Box component="form" onSubmit={handleSubmit}>
       <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
         <Typography variant="h4" gutterBottom>
-          機器登録
+          {id ? '機器編集' : '機器登録'}
         </Typography>
       </Box>
 
@@ -112,7 +176,7 @@ export const DeviceForm = () => {
         <Box display="flex" gap={2}>
           <Button
             variant="text"
-            onClick={() => navigate('/devices')}
+            onClick={handleCancel}
             disabled={loading}
           >
             キャンセル
@@ -122,10 +186,25 @@ export const DeviceForm = () => {
             loading={loading}
             disabled={loading || Object.keys(errors).length > 0}
           >
-            登録
+            {id ? '更新' : '登録'}
           </Button>
         </Box>
       </Stack>
+
+      <Dialog
+        open={showCancelDialog}
+        title="確認"
+        confirmText="はい"
+        cancelText="いいえ"
+        onConfirm={() => navigate('/devices')}
+        onCancel={() => setShowCancelDialog(false)}
+      >
+        <Typography>
+          変更内容が保存されていません。
+          <br />
+          一覧画面に戻りますか？
+        </Typography>
+      </Dialog>
 
       <Snackbar
         open={!!successMessage}


### PR DESCRIPTION
## issue
- closes  #24

# プルリクエスト: 機器編集画面の実装 (#24)

## 概要
機器編集画面の実装を行いました。既存の機器情報の編集機能、バリデーション機能、およびユーザビリティの向上を実現しています。

## 実装内容

### 1. 編集機能の実装
- 既存機器データの取得と表示
- 更新処理の実装（PUT API連携）
- 成功時の一覧画面への自動遷移
- ローディング状態の表示

### 2. バリデーション機能
#### 2.1 入力チェック
- 必須入力チェック（機器名、メーカー名）
- 文字種チェック
  ```typescript
  // 使用可能文字
  - 日本語（ひらがな、カタカナ、漢字）
  - 英数字
  - 記号（. , & ! @ # ( ) （ ） ［ ］ ・ 、 。 - _）
  - スペース
  ```

#### 2.2 重複チェック
- 同一の機器名とメーカーの組み合わせを禁止
- 更新時は自身のレコードを除外して重複チェック

### 3. エラーハンドリング
- バリデーションエラーの表示
- APIエラーの表示
- 具体的なエラーメッセージの実装
  ```typescript
  // 重複エラー時
  "この機器（機器名：XXX、メーカー：YYY）は既に登録されています"
  
  // 文字種エラー時
  "使用できない文字が含まれています。使用可能な文字：日本語、英数字、記号（. , & ! @ # ( ) （ ） ［ ］ ・ 、 。 - _）"
  ```

### 4. UI/UX改善
- キャンセル時の確認ダイアログ
- 成功時のフィードバック表示
- フォーム入力状態の追跡
- ボタンの状態管理（ローディング、無効化）

## 変更ファイル
```
frontend/src/pages/devices/DeviceForm.tsx
backend/lambda/devices/handlers/device_handlers.py
```

## 動作確認項目

### 1. 基本機能
- [ ] 編集画面への遷移
- [ ] 既存データの表示
- [ ] データ更新処理
- [ ] 一覧画面への遷移

### 2. バリデーション
- [ ] 必須入力チェック
- [ ] 文字種チェック
- [ ] 重複チェック
- [ ] エラーメッセージの表示

### 3. エラーハンドリング
- [ ] バリデーションエラー時の処理
- [ ] API通信エラー時の処理
- [ ] エラーメッセージの表示

### 4. UI/UX
- [ ] キャンセル確認ダイアログ
- [ ] 成功時のメッセージ表示
- [ ] ローディング表示
- [ ] ボタンの状態管理

## テストケース

### 1. 正常系
1. 既存機器の編集
   - 機器名のみ変更
   - メーカー名のみ変更
   - 両方変更

2. 入力文字種
   - 日本語入力
   - 英数字入力
   - 記号入力
   - 複合的な入力

### 2. 異常系
1. バリデーションエラー
   - 必須項目の未入力
   - 使用不可文字の入力
   - 重複データの登録

2. エラー処理
   - API通信エラー
   - バリデーションエラー
   - 重複エラー

## 備考
- フロントエンド、バックエンド双方でバリデーションを実装し、UXと整合性を確保
- エラーメッセージは具体的で分かりやすい表現を採用
- 既存のコンポーネントを活用し、UIの一貫性を維持

## 関連Issue
- #24 機器編集画面の作成
