### PR TITLE
##27/Phase 4: デプロイ実行4.1 バックエンドデプロイ

### DIFF
--- a/backend/lambda/devices/handlers/device_handlers.py
+++ b/backend/lambda/devices/handlers/device_handlers.py
@@ -44,10 +44,10 @@ app = FastAPI(
 # CORSミドルウェアの設定
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # 本番環境では適切なオリジンに制限すること
+    allow_origins=["https://dwe4u6ecffp1b.cloudfront.net"],  # CloudFrontドメインに制限
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization", "X-Api-Key"],
 )
 
 router = APIRouter()


### PR DESCRIPTION
## issue
- closes  #27 

# バックエンドデプロイ設定 プルリクエストまとめ

## 実装内容
1. **CORS設定の本番環境対応**
   - 許可オリジンを `https://dwe4u6ecffp1b.cloudfront.net` に制限
   - HTTPメソッドを明示的に指定 (`GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`)
   - 許可ヘッダーを必要最小限に設定 (`Content-Type`, `Authorization`, `X-Api-Key`)

2. **Lambda関数のデプロイ**
   - 関数名: `device-management-api`
   - ランタイム: `python3.9`
   - メモリ: 256MB
   - タイムアウト: 30秒
   - VPC設定: 既存のVPCとセキュリティグループを使用

3. **API Gatewayの更新**
   - 新しいデプロイメント作成（ID: `etz90s`）
   - ステージ: `dev`

4. **フロントエンド環境変数の更新**
   - API Gateway エンドポイントを設定
   ```
   VITE_API_BASE_URL=https://w94vqqa7n0.execute-api.ap-northeast-1.amazonaws.com/dev
   ```

## 動作確認済み項目
- ✅ Lambda関数のデプロイ成功
- ✅ API Gatewayのデプロイメント成功
- ✅ 環境変数の更新完了

## 技術的な注意点
1. CORSは本番環境用に厳格に設定
2. Lambda関数はVPC内にデプロイ
3. API Gatewayのエンドポイントはフロントエンドからのみアクセス可能

## 関連ファイル
1. `backend/lambda/devices/handlers/device_handlers.py`
2. `frontend/.env.production`